### PR TITLE
Fix improper hour reading

### DIFF
--- a/src/com/hms_networks/americas/sc/localdatafiles/LocalDataFileManager.java
+++ b/src/com/hms_networks/americas/sc/localdatafiles/LocalDataFileManager.java
@@ -89,7 +89,7 @@ public class LocalDataFileManager extends Thread {
     String year = String.valueOf(calendar.get(Calendar.YEAR));
     String month = String.valueOf(calendar.get(Calendar.MONTH) + 1);
     String day = String.valueOf(calendar.get(Calendar.DAY_OF_MONTH));
-    String hour = String.valueOf(calendar.get(Calendar.HOUR));
+    String hour = String.valueOf(calendar.get(Calendar.HOUR_OF_DAY));
 
     // Pad month, day and hour with leading zero if only one digit
     month = month.length() == 1 ? "0" + month : month;


### PR DESCRIPTION
The hour was being read as 12-hour, not 24-hour, which caused existing files to be overwritten